### PR TITLE
Fixed MPU9250 Compatibility Issues on Arduino Due

### DIFF
--- a/MPU9250/MPU9250.ino
+++ b/MPU9250/MPU9250.ino
@@ -1,7 +1,7 @@
 /*
  * ## Note to Testers ##
  * 
- * FFT is by default OFF
+ * FFT is by default ON (in this version)
  * To turn FFT on, please refer to line 64 below,
  * and refer to line 18-23 in src/MPU9250.h
  */
@@ -15,20 +15,13 @@
 #define BAUDRATE 115200
 #define THISARDUINO ARDUINO_ONE
 
-// Objects for each sensor
-MPU9250 mpu9250(THISARDUINO); 
-//...
-
-Sensor* sensors[NUMSENSORS] = {
-    // Entry for each sensor object
-    &mpu9250, 
-    //...
-};
+Sensor* sensors[NUMSENSORS];
 
 // !#!#!#!--- EVERYTHING AFTER HERE DOES NOT NEED TO BE CHANGED FOR SENSOR IMPLEMENTATION ---!#!#!#!
 
 void setup(){
     Serial.begin(BAUDRATE);
+    sensors[0] = new MPU9250(THISARDUINO);
 
     bool success = true;
     for(int i = 0; i < NUMSENSORS; i++){
@@ -81,3 +74,4 @@ void loop(){
         }
     }
 }
+

--- a/MPU9250/src/MPU9250.cpp
+++ b/MPU9250/src/MPU9250.cpp
@@ -1,6 +1,6 @@
 #include "MPU9250.h"
-
-const char *arr[10] = {"mg [X]", "mg [Y]", "mg [Z]", "deg/sec [X]", "deg/sec [Y]", "deg/sec [Z]", "mG [X]", "mG [Y]", "mG [Z]", "mg/Hz Peak [" FFT_AXIS "]"};
+//TODO the last unit is hardcoded
+const char *arr[10] = {"mg [X]", "mg [Y]", "mg [Z]", "deg/sec [X]", "deg/sec [Y]", "deg/sec [Z]", "mG [X]", "mG [Y]", "mG [Z]", "mg/Hz Peak [X]"};
 t_datasetup datasetup = {10, arr};
 
 arduinoFFT FFT = arduinoFFT();
@@ -97,7 +97,7 @@ double computeFFT(double vReal[]) {
 // TODO Calibrate imu readings
 errorlevel_t MPU9250::read(t_datum *data, uint8_t numdata) {
     // NOTE: Convention - check that numdata given matches expected
-    if (numdata != 9)
+    if (numdata != 10)
     { //TODO: globally declare the array size instead of using the int value
         return ERR_FAIL;
     }
@@ -111,13 +111,13 @@ errorlevel_t MPU9250::read(t_datum *data, uint8_t numdata) {
         // Can only be configured for one axis only, due to memory constraint
         // For other axes, set FFT_AXIS 'x', 'y', 'z'
         switch (FFT_AXIS) {
-        case "x":
+        case 'x':
             vReal[count] = (double)mpu9250.ax;
             break;
-        case "y":
+        case 'y':
             vReal[count] = (double)mpu9250.ay;
             break;
-        case "z":
+        case 'z':
             vReal[count] = (double)mpu9250.az;
             break;
         }

--- a/MPU9250/src/MPU9250.h
+++ b/MPU9250/src/MPU9250.h
@@ -11,11 +11,11 @@
 #define I2Cclock 400000     // Options: 100k, 400k
 #define I2Cport Wire
 #define MPU9250_ADDRESS 104 // I2C Address: 0x68
-#define FFT_AXIS "x"        // Can set FFT_AXIZ to 'x', 'y', or 'z'
+#define FFT_AXIS 'x'       // Can set FFT_AXIZ to 'x', 'y', or 'z'
 #define SAMPLES 256         // Must be a power of 2
 #define SAMPLING_FREQUENCY 1000
 
-#define ENABLE_FFT false     // Set to true for FFT calculations
+#define ENABLE_FFT true     // Set to true for FFT calculations
 /**
  * For FFT, set the last parameter to 1 in MPU9250 constructor in MPU9250.cpp on line 13
  *     Reason being that FFT requires 256 samples


### PR DESCRIPTION
The `MPU9250_Lib` couldn't be declared as a global variable, which caused the code to get stuck trying to declare `MPU9250`. Fixed this by declaring the 'MPU9250'  object dynamically in the `setup` function. Realized an issue with the `datasetuo units` array, it's not possible to include the dimension of the frequency measured `FFT_AXIS` (need to manipulate chars).